### PR TITLE
Disposing bug fix

### DIFF
--- a/SegmentedControl/SegmentedControl.FormsPlugin.iOS/SegmentedControlImplementation.cs
+++ b/SegmentedControl/SegmentedControl.FormsPlugin.iOS/SegmentedControlImplementation.cs
@@ -108,6 +108,8 @@ namespace SegmentedControl.FormsPlugin.iOS
 
 			try
 			{
+				if (disposing)
+					SetElement(null);
 				base.Dispose(disposing);
 			}
 			catch (Exception ex)


### PR DESCRIPTION
Potential fix for "Object reference not set to an instance of an object" issue while disposing control.